### PR TITLE
Change the default ‘C-c w’ and ‘C-c W’ key-bindings

### DIFF
--- a/wiki-nav.el
+++ b/wiki-nav.el
@@ -438,7 +438,7 @@ Set this value to nil to disable."
   "Keyboard bindings used by wiki-nav"
   :group 'wiki-nav)
 
-(defcustom wiki-nav-find-any-link-keys '("C-c w")
+(defcustom wiki-nav-find-any-link-keys '("C-c C-w")
   "List of key sequences to search forward for the next defined wiki-nav link.
 
 The search will automatically wrap past the end of the buffer.
@@ -449,7 +449,7 @@ The format for key sequences is as defined by `kbd'."
   :type '(repeat string)
   :group 'wiki-nav-keys)
 
-(defcustom wiki-nav-find-any-previous-link-keys '("C-c W")
+(defcustom wiki-nav-find-any-previous-link-keys '("C-c C-W")
   "List of key sequences to search backward for the previous wiki-nav link.
 
 The search will automatically wrap past the beginning of the


### PR DESCRIPTION
Section 22.2.1 of the Emacs Lisp Manual, “Major Mode Conventions,”
says the following about keys:

```
The key sequences bound in a major mode keymap should usually
start with ‘C-c’, followed by a control character, a digit, or
‘{’, ‘}’, ‘<’, ‘>’, ‘:’ or ‘;’.  The other punctuation characters
are reserved for minor modes, and ordinary letters are reserved
for users.
```

Users should be able to safely use a key sequence such as ‘C-c w’
without concern for conflicts with any major mode.  However, Wiki Nav
Mode violates that reservation.  Therefore, this patch changes

```
C-c w    ->    C-c C-w
C-c W    ->    C-c C-W
```

in order to avoid conflicts with users’ keys.
