### PR TITLE
Optimization: single whole-buffer fontification run in wiki-nav

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,12 +87,12 @@ test-tests :
 test-prep : build test-dep-1 test-autoloads test-travis test-tests
 
 test-batch :
-	@cd '$(TEST_DIR)'                                 && \
-	(for test_lib in *-test.el; do                       \
-	   $(RESOLVED_EMACS) $(EMACS_BATCH) -L . -L .. -l cl \
-	   -l '$(TEST_DEP_1)' -l "$$test_lib" --eval         \
-	    "(progn                                          \
-	      (fset 'ert--print-backtrace 'ignore)           \
+	@cd '$(TEST_DIR)'                                 &&     \
+	(for test_lib in *-test.el; do                           \
+	   $(RESOLVED_EMACS) $(EMACS_BATCH) -L . -L .. -l cl-lib \
+	   -l '$(TEST_DEP_1)' -l "$$test_lib" --eval             \
+	    "(progn                                              \
+	      (fset 'ert--print-backtrace 'ignore)               \
 	      (ert-run-tests-batch-and-exit '(and \"$(TESTS)\" (not (tag :interactive)))))" || exit 1; \
 	done)
 
@@ -105,7 +105,7 @@ test-interactive : test-prep
 	      (setq dired-use-ls-dired nil)                              \
 	      (setq frame-title-format \"TEST SESSION $$test_lib\")      \
 	      (setq enable-local-variables :safe))"                      \
-	    -L . -L .. -l cl -l '$(TEST_DEP_1)' -l "$$test_lib"          \
+	    -L . -L .. -l cl-lib -l '$(TEST_DEP_1)' -l "$$test_lib"      \
 	    --visit "$$test_lib" --eval                                  \
 	    "(progn                                                      \
 	      (when (> (length \"$(TESTS)\") 0)                          \

--- a/README.markdown
+++ b/README.markdown
@@ -83,9 +83,9 @@ Example usage:
 
 		[[links]]
 
-   in your files.  That's it.  There's more functionality, but simple `[[links]]`
-   may be all you need.  When you click on `[[links]]`, the point jumps forward
-   in the buffer to the next matching wiki-nav link.
+	in your files.  That's it.  There's more functionality, but simple `[[links]]`
+	may be all you need.  When you click on `[[links]]`, the point jumps forward
+	in the buffer to the next matching wiki-nav link.
 
 ## Advanced usage
 

--- a/button-lock.el
+++ b/button-lock.el
@@ -1,12 +1,12 @@
 ;;; button-lock.el --- Clickable text defined by regular expression
 ;;
-;; Copyright (c) 2011-2015 Roland Walker
+;; Copyright (c) 2011-2023 Roland Walker
 ;;
 ;; Author: Roland Walker <walker@pobox.com>
 ;; Homepage: http://github.com/rolandwalker/button-lock
 ;; URL: http://raw.githubusercontent.com/rolandwalker/button-lock/master/button-lock.el
 ;; Version: 1.0.2
-;; Last-Updated: 21 Feb 2015
+;; Last-Updated: 4 Mar 2023
 ;; EmacsWiki: ButtonLockMode
 ;; Keywords: mouse, button, hypermedia, extensions
 ;;
@@ -232,14 +232,14 @@
 ;; without modification, are permitted provided that the following
 ;; conditions are met:
 ;;
-;;    1. Redistributions of source code must retain the above
-;;       copyright notice, this list of conditions and the following
-;;       disclaimer.
+;;   1. Redistributions of source code must retain the above
+;;      copyright notice, this list of conditions and the following
+;;      disclaimer.
 ;;
-;;    2. Redistributions in binary form must reproduce the above
-;;       copyright notice, this list of conditions and the following
-;;       disclaimer in the documentation and/or other materials
-;;       provided with the distribution.
+;;   2. Redistributions in binary form must reproduce the above
+;;      copyright notice, this list of conditions and the following
+;;      disclaimer in the documentation and/or other materials
+;;      provided with the distribution.
 ;;
 ;; Ths software is provided by Roland Walker "AS IS" and any express
 ;; or implied warranties, including, but not limited to, the implied
@@ -373,17 +373,17 @@ lighter for `button-lock-mode'."
 ;;; faces
 
 (defface button-lock-button-face
-    '((t nil))
-    "Face used to show active button-lock buttons.
+  '((t nil))
+  "Face used to show active button-lock buttons.
 
 The default is for buttons to inherit whatever properties are
 already provided by font-lock."
     :group 'button-lock)
 
 (defface button-lock-mouse-face
-   '((t (:inherit highlight)))
-   "Face used to highlight button-lock buttons when the mouse hovers over."
-   :group 'button-lock)
+  '((t (:inherit highlight)))
+  "Face used to highlight button-lock buttons when the mouse hovers over."
+  :group 'button-lock)
 
 ;;; variables
 
@@ -676,10 +676,10 @@ the argument is 'toggle."
 
 button-lock mode will be activated in every buffer, except
 
-   minibuffers
-   buffers with names that begin with space
-   buffers excluded by `button-lock-exclude-modes'
-   buffers excluded by `button-lock-buffer-name-exclude-pattern'
+    minibuffers
+    buffers with names that begin with space
+    buffers excluded by `button-lock-exclude-modes'
+    buffers excluded by `button-lock-buffer-name-exclude-pattern'
 
 If called with a negative ARG, deactivate button-lock mode in the
 buffer."

--- a/button-lock.el
+++ b/button-lock.el
@@ -477,7 +477,7 @@ Returns nil if the current major mode is not a derived mode."
         buf))))
 
 (defun button-lock-maybe-unbuttonify-buffer ()
-  "This is a workaround for cperl mode, which clobbers `font-lock-unfontify-region-function'."
+  "For cperl mode, which clobbers `font-lock-unfontify-region-function'."
   (when (and (boundp 'font-lock-fontified)
              font-lock-fontified
              (not (eq font-lock-unfontify-region-function 'font-lock-default-unfontify-region)))
@@ -644,7 +644,9 @@ argument, it enables the mode if the argument is positive and
 otherwise disables it.  When called from Lisp, it enables the
 mode if the argument is omitted or nil, and toggles the mode if
 the argument is 'toggle."
-  nil button-lock-mode-lighter nil
+  :init-value nil
+  :lighter button-lock-mode-lighter
+  :keymap nil
   (cond
     ((and button-lock-mode
           (or noninteractive                    ; never turn on button-lock where

--- a/wiki-nav.el
+++ b/wiki-nav.el
@@ -1038,7 +1038,9 @@ match URLs and non-URL inner text.
 With no argument, this command toggles the mode.  Non-null prefix
 argument turns on the mode.  Null prefix argument turns off the
 mode."
-  nil wiki-nav-mode-lighter wiki-nav-mode-keymap
+  :init-value nil
+  :lighter wiki-nav-mode-lighter
+  :keymap wiki-nav-mode-keymap
   (cond
     ((and wiki-nav-mode
           (or noninteractive                    ; never turn on wiki-nav where

--- a/wiki-nav.el
+++ b/wiki-nav.el
@@ -1,12 +1,12 @@
 ;;; wiki-nav.el --- Simple file navigation using [[WikiStrings]]
 ;;
-;; Copyright (c) 2011-2015 Roland Walker
+;; Copyright (c) 2011-2023 Roland Walker
 ;;
 ;; Author: Roland Walker <walker@pobox.com>
 ;; Homepage: http://github.com/rolandwalker/button-lock
 ;; URL: http://raw.githubusercontent.com/rolandwalker/button-lock/master/wiki-nav.el
 ;; Version: 1.0.2
-;; Last-Updated: 23 Feb 2015
+;; Last-Updated: 4 Mar 2023
 ;; EmacsWiki: WikiNavMode
 ;; Keywords: mouse, button, hypermedia, navigation
 ;; Package-Requires: ((button-lock "1.0.2") (nav-flash "1.0.0"))
@@ -219,6 +219,9 @@
 ;;     in buffer as is done in fixmee-mode, and use syntax-ppss rather
 ;;     than regexp to detect comment context
 ;;
+;;     avoid mistaking common construct if [[ ... for a link in commented-
+;;     out shell code
+;;
 ;;     support kbd-help property
 ;;
 ;;     follow the doc for defgroup to find link functions which are
@@ -284,14 +287,14 @@
 ;; without modification, are permitted provided that the following
 ;; conditions are met:
 ;;
-;;    1. Redistributions of source code must retain the above
-;;       copyright notice, this list of conditions and the following
-;;       disclaimer.
+;;   1. Redistributions of source code must retain the above
+;;      copyright notice, this list of conditions and the following
+;;      disclaimer.
 ;;
-;;    2. Redistributions in binary form must reproduce the above
-;;       copyright notice, this list of conditions and the following
-;;       disclaimer in the documentation and/or other materials
-;;       provided with the distribution.
+;;   2. Redistributions in binary form must reproduce the above
+;;      copyright notice, this list of conditions and the following
+;;      disclaimer in the documentation and/or other materials
+;;      provided with the distribution.
 ;;
 ;; This software is provided by Roland Walker "AS IS" and any express
 ;; or implied warranties, including, but not limited to, the implied
@@ -472,12 +475,12 @@ The format for key sequences is as defined by `kbd'."
   :group 'wiki-nav)
 
 (defface wiki-nav-link-face
-   '((t (:inherit link)))
+  '((t (:inherit link)))
   "Face to show wiki-nav links"
   :group 'wiki-nav-faces)
 
 (defface wiki-nav-mouse-face
-   '((t (:inherit button-lock-mouse-face)))
+  '((t (:inherit button-lock-mouse-face)))
   "Face to highlight wiki-nav link mouseovers"
   :group 'wiki-nav-faces)
 
@@ -514,10 +517,10 @@ The value should exclude newlines and start/stop delimiters."
 
 The default is very permissive.  To be more strict, try
 
-   \"\\\\`[a-zA-Z]+://[^[:space:]]+\",
+    \"\\\\`[a-zA-Z]+://[^[:space:]]+\",
 or
 
-   \"\\\\`http://[^[:space:]]+\".
+    \"\\\\`http://[^[:space:]]+\".
 
 Setting the value to the empty string will disable the feature
 entirely, suppressing the recognition of external URLs."
@@ -529,16 +532,16 @@ entirely, suppressing the recognition of external URLs."
 
 The format defined by the default expression is delimited by colons
 
-   visit:/posix/path/to/another/file
+    visit:/posix/path/to/another/file
 
-      or
+        or
 
-   visit:/posix/path/to/another/file:WikiString
+    visit:/posix/path/to/another/file:WikiString
 
 Other internally recognized link schemes may be substituted for
 the WikiString
 
-   visit:/posix/path/to/another/file:line:10
+    visit:/posix/path/to/another/file:line:10
 
 Set this value to the empty string to disable the feature entirely."
   :type 'regexp
@@ -549,7 +552,7 @@ Set this value to the empty string to disable the feature entirely."
 
 The format defined by the default expression is delimited by colons
 
-   func:function_name
+    func:function_name
 
 Imenu is used to find the function definition.
 
@@ -562,7 +565,7 @@ Set this value to the empty string to disable the feature entirely."
 
 The format defined by the default expression is delimited by colons
 
-   line:111
+    line:111
 
 Set this value to the empty string to disable the feature entirely."
   :type 'regexp
@@ -717,8 +720,7 @@ Returns `point-min' if the point is at the minimum."
     (t
      (list list))))
 
-;; buffer functions
-
+;; buffer utility functions
 (defun wiki-nav-buffer-included-p (buf)
   "Return BUF if global wiki-nav should enable wiki-nav in BUF."
   (when (and (not noninteractive)
@@ -745,7 +747,8 @@ Returns `point-min' if the point is at the minimum."
                    t))
         buf))))
 
-;; link functions
+;;; link functions
+
 (defun wiki-nav-link-set (&optional arg)
   "Use `button-lock-mode' to set up wiki-nav links in a buffer.
 
@@ -815,7 +818,8 @@ seconds to complete."
     (progress-reporter-done reporter)
     (delq nil (wiki-nav-alist-flatten l-alist))))
 
-;; bindable action dispatch commands
+;;; bindable action dispatch commands
+
 ;;;###autoload
 (defun wiki-nav-default-multi-action (event)
   "Dispatch the default double-click navigation action.
@@ -1009,7 +1013,7 @@ all open file buffers.
 
 If the link follows the form
 
-   visit:/path/name:WikiString
+    visit:/path/name:WikiString
 
 Emacs will visit the named file, and search for the navigation
 string there.  This behavior can be controlled by the customizable
@@ -1017,7 +1021,7 @@ variable `wiki-nav-visit-link-pattern'.
 
 If the link follows the form
 
-   func:FunctionName
+    func:FunctionName
 
 the link will lead to the definition of the given function, as
 defined by imenu. This behavior can be controlled by the
@@ -1025,7 +1029,7 @@ customizable variable `wiki-nav-function-link-pattern'.
 
 If the link follows the form
 
-   line:<digits>
+    line:<digits>
 
 the link will lead to the given line number.  This behavior can
 be controlled by the customizable variable
@@ -1062,12 +1066,12 @@ mode."
 
 `wiki-nav-mode' will be activated in every buffer, except
 
-   minibuffers
-   buffers with names that begin with space
-   buffers excluded by `wiki-nav-exclude-modes'
-   buffers excluded by `button-lock-exclude-modes'
-   buffers excluded by `wiki-nav-buffer-name-exclude-pattern'
-   buffers excluded by `button-lock-buffer-name-exclude-pattern'
+    minibuffers
+    buffers with names that begin with space
+    buffers excluded by `wiki-nav-exclude-modes'
+    buffers excluded by `button-lock-exclude-modes'
+    buffers excluded by `wiki-nav-buffer-name-exclude-pattern'
+    buffers excluded by `button-lock-buffer-name-exclude-pattern'
 
 If called with a negative ARG, deactivate `wiki-nav-mode' in the buffer."
   (cl-callf or arg 1)


### PR DESCRIPTION
Incidentally
 * clean up `'cl` references
 * clean up byte-compile lint
 * tidy up many comments and docstrings
 * update copyright